### PR TITLE
Add ability to choose msg/flow/global scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@
 
 ## Feature
 
-* Can only increment.
-* Increment any property of message object.
+* Can increment by any number/factor
+* Can increment and decrement (by setting negative factor)
+* Increment any property of message/flow/global object
 
 ## Install
 

--- a/increment.html
+++ b/increment.html
@@ -1,16 +1,36 @@
 <script type='text/javascript'>
     RED.nodes.registerType('increment', {
-        category: 'advanced',
+        category: 'function',
         color: '#4DB6AC',
         defaults: {
             name: { value: '' },
+            kind: { value: 'msg' },
             target: { value: 'payload' }
         },
         inputs: 1,
         outputs: 1,
         icon: 'increment.png',
         label: function () {
-            return this.name || "msg." + this.target + "++";
+            if (!this.kind) this.kind = this._def.defaults.kind.value;
+            return this.name || this.kind + '.' + this.target + "++";
+        },
+        oneditprepare: function onEditPrepare() {
+          var propertyName = $('<input/>', {
+            id: 'node-typed-input-target',
+            type: 'text',
+            style: 'margin-left: 5px;'
+          })
+          .appendTo('#node-input-target-container')
+          .typedInput({
+            types: ['msg','flow','global']
+          });
+
+          propertyName.typedInput('type', this.kind);
+          propertyName.typedInput('value', this.target);
+        },
+        oneditsave: function onEditSave() {
+          $('#node-input-kind').val($('#node-typed-input-target').typedInput('type'));
+          $('#node-input-target').val($('#node-typed-input-target').typedInput('value'));
         }
     });
 </script>
@@ -19,9 +39,10 @@
         <label for='node-input-name'><i class='fa fa-tag'></i>Name</label>
         <input type='text' id='node-input-name' placeholder='Name'>
     </div>
-    <div class="form-row">
-        <label for="node-input-target"><i class="fa fa-tag"></i>Target</label> msg.
-        <input type="text" id="node-input-target" placeholder='payload'>
+    <div class="form-row" id="node-input-target-container">
+        <label for="node-input-target"><i class="fa fa-tag"></i>Target</label>
+        <input type="hidden" id="node-input-kind">
+        <input type="hidden" id="node-input-target">
     </div>
 </script>
 <script type='text/x-red' data-help-name='increment'>

--- a/increment.html
+++ b/increment.html
@@ -5,7 +5,8 @@
         defaults: {
             name: { value: '' },
             kind: { value: 'msg' },
-            target: { value: 'payload' }
+            target: { value: 'payload' },
+            factor: { value: 1 }
         },
         inputs: 1,
         outputs: 1,
@@ -40,14 +41,18 @@
         <input type='text' id='node-input-name' placeholder='Name'>
     </div>
     <div class="form-row" id="node-input-target-container">
-        <label for="node-input-target"><i class="fa fa-tag"></i>Target</label>
+        <label for="node-input-target"><i class="fa fa-target"></i>Target</label>
         <input type="hidden" id="node-input-kind">
         <input type="hidden" id="node-input-target">
+    </div>
+    <div class='form-row'>
+        <label for='node-input-factor'><i class='fa fa-graph'></i>Factor</label>
+        <input type='number' id='node-input-factor' placeholder='Factor (default: 1)'>
     </div>
 </script>
 <script type='text/x-red' data-help-name='increment'>
     <dl>
         <dt>output</dt>
-        <dd>msg.payload += 1;</dd>
+        <dd>msg.payload += factor;</dd>
     </dl>
 </script>

--- a/increment.html
+++ b/increment.html
@@ -6,7 +6,7 @@
             name: { value: '' },
             kind: { value: 'msg' },
             target: { value: 'payload' },
-            factor: { value: 1 }
+            increment: { value: 1 }
         },
         inputs: 1,
         outputs: 1,
@@ -41,18 +41,18 @@
         <input type='text' id='node-input-name' placeholder='Name'>
     </div>
     <div class="form-row" id="node-input-target-container">
-        <label for="node-input-target"><i class="fa fa-target"></i>Target</label>
+        <label for="node-input-target"><i class="fa fa-map-pin"></i>Target</label>
         <input type="hidden" id="node-input-kind">
         <input type="hidden" id="node-input-target">
     </div>
     <div class='form-row'>
-        <label for='node-input-factor'><i class='fa fa-graph'></i>Factor</label>
-        <input type='number' id='node-input-factor' placeholder='Factor (default: 1)'>
+        <label for='node-input-increment'><i class='fa fa-plus'></i>Increment</label>
+        <input type='number' id='node-input-increment' placeholder='Increment (default: 1)'>
     </div>
 </script>
 <script type='text/x-red' data-help-name='increment'>
     <dl>
         <dt>output</dt>
-        <dd>msg.payload += factor;</dd>
+        <dd>msg.payload += increment;</dd>
     </dl>
 </script>

--- a/increment.js
+++ b/increment.js
@@ -1,22 +1,33 @@
 module.exports = function (RED) {
-    function increment(val) {
-      if (typeof val === 'undefined') return 1;
-      return Number(val) + 1;
+    function isEmpty(val) {
+      return typeof val === 'undefined'
+          || val === 'undefined'
+          || val === '';
+    }
+
+    function increment(val, factor) {
+      if (isEmpty(factor)) {
+          factor = 1;
+      }
+      factor = Number(factor);
+      if (isEmpty(val)) return factor;
+      return Number(val) + factor;
     }
     function incNode(config) {
         RED.nodes.createNode(this, config);
         this.kind = config.kind;
         this.target = config.target;
+        this.factor = config.factor;
         var node = this;
         this.on('input', function (msg) {
             if (!this.kind || this.kind === 'msg') {
-              msg[node.target] = increment(msg[node.target]);
+              msg[node.target] = increment(msg[node.target], node.factor);
               console.log(' msg[node.target]', msg[node.target], node)
 
             } else if (this.kind === 'flow') {
-              node.context().flow.set(node.target, increment(node.context().flow.get(node.target)));
+              node.context().flow.set(node.target, increment(node.context().flow.get(node.target), node.factor));
             } else if (this.kind === 'global') {
-              node.context().global.set(node.target, increment(node.context().global.get(node.target)));
+              node.context().global.set(node.target, increment(node.context().global.get(node.target), node.factor));
             }
             node.send(msg);
         });

--- a/increment.js
+++ b/increment.js
@@ -1,10 +1,23 @@
 module.exports = function (RED) {
+    function increment(val) {
+      if (typeof val === 'undefined') return 1;
+      return Number(val) + 1;
+    }
     function incNode(config) {
         RED.nodes.createNode(this, config);
+        this.kind = config.kind;
         this.target = config.target;
         var node = this;
         this.on('input', function (msg) {
-            msg[node.target] = Number(msg[node.target]) + 1;
+            if (!this.kind || this.kind === 'msg') {
+              msg[node.target] = increment(msg[node.target]);
+              console.log(' msg[node.target]', msg[node.target], node)
+
+            } else if (this.kind === 'flow') {
+              node.context().flow.set(node.target, increment(node.context().flow.get(node.target)));
+            } else if (this.kind === 'global') {
+              node.context().global.set(node.target, increment(node.context().global.get(node.target)));
+            }
             node.send(msg);
         });
     }

--- a/increment.js
+++ b/increment.js
@@ -5,29 +5,29 @@ module.exports = function (RED) {
           || val === '';
     }
 
-    function increment(val, factor) {
-      if (isEmpty(factor)) {
-          factor = 1;
+    function incrementVal(val, increment) {
+      if (isEmpty(increment)) {
+          increment = 1;
       }
-      factor = Number(factor);
-      if (isEmpty(val)) return factor;
-      return Number(val) + factor;
+      increment = Number(increment);
+      if (isEmpty(val)) return increment;
+      return Number(val) + increment;
     }
     function incNode(config) {
         RED.nodes.createNode(this, config);
         this.kind = config.kind;
         this.target = config.target;
-        this.factor = config.factor;
+        this.increment = config.increment;
         var node = this;
         this.on('input', function (msg) {
             if (!this.kind || this.kind === 'msg') {
-              msg[node.target] = increment(msg[node.target], node.factor);
+              msg[node.target] = incrementVal(msg[node.target], node.increment);
               console.log(' msg[node.target]', msg[node.target], node)
 
             } else if (this.kind === 'flow') {
-              node.context().flow.set(node.target, increment(node.context().flow.get(node.target), node.factor));
+              node.context().flow.set(node.target, incrementVal(node.context().flow.get(node.target), node.increment));
             } else if (this.kind === 'global') {
-              node.context().global.set(node.target, increment(node.context().global.get(node.target), node.factor));
+              node.context().global.set(node.target, incrementVal(node.context().global.get(node.target), node.increment));
             }
             node.send(msg);
         });


### PR DESCRIPTION
This PR introduces two additional properties:
- target namespace (choose between `msg`, `flow` or `global`)
- increment value

<img width="463" alt="screen shot 2017-11-21 at 12 56 26" src="https://user-images.githubusercontent.com/25722/33071343-76bbb7fc-cebb-11e7-8596-7dba1ff1925e.png">

It makes this node more flexible and also allows to decrement by setting negative increment value!